### PR TITLE
Feature/gestao rachas

### DIFF
--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/application/dto/CreateRachaDTO.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/application/dto/CreateRachaDTO.java
@@ -1,0 +1,11 @@
+package br.com.rachaplus.api.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateRachaDTO(
+        @NotBlank(message = "The name is required")
+        String name,
+
+        String description
+) {
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/application/dto/RachaMemberResponseDTO.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/application/dto/RachaMemberResponseDTO.java
@@ -1,0 +1,26 @@
+package br.com.rachaplus.api.application.dto;
+
+import br.com.rachaplus.api.domain.RachaMember;
+import br.com.rachaplus.api.domain.RachaRole;
+
+import java.util.UUID;
+
+public record RachaMemberResponseDTO(
+        UUID rachaId,
+        String rachaName,
+        UUID userId,
+        String userName,
+        float rachaRating,
+        RachaRole role
+) {
+    public RachaMemberResponseDTO(RachaMember member) {
+        this(
+                member.getRacha().getId(),
+                member.getRacha().getName(),
+                member.getUser().getId(),
+                member.getUser().getNome(),
+                member.getRachaRating(),
+                member.getRole()
+        );
+    }
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/application/dto/RachaResponseDTO.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/application/dto/RachaResponseDTO.java
@@ -1,0 +1,17 @@
+package br.com.rachaplus.api.application.dto;
+
+import br.com.rachaplus.api.domain.Racha;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record RachaResponseDTO(
+        UUID id,
+        String name,
+        String description,
+        LocalDateTime createdAt
+) {
+    public RachaResponseDTO(Racha racha) {
+        this(racha.getId(), racha.getName(), racha.getDescription(), racha.getCreatedAt());
+    }
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/application/service/RachaService.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/application/service/RachaService.java
@@ -14,8 +14,6 @@ import java.util.UUID;
 @Service
 public class RachaService {
 
-    private final float defaultRating = 0.0f;
-
     private final RachaRepository rachaRepository;
     private final RachaMemberRepository rachaMemberRepository;
 
@@ -25,6 +23,8 @@ public class RachaService {
     }
 
     public Racha create(String name, String description, Usuario owner) {
+        final float defaultRating = 0.0f;
+
         var newRacha = new Racha();
         newRacha.setName(name);
         newRacha.setDescription(description);

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/application/service/RachaService.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/application/service/RachaService.java
@@ -1,0 +1,57 @@
+package br.com.rachaplus.api.application.service;
+
+import br.com.rachaplus.api.domain.Racha;
+import br.com.rachaplus.api.domain.RachaMember;
+import br.com.rachaplus.api.domain.RachaRole;
+import br.com.rachaplus.api.domain.Usuario;
+import br.com.rachaplus.api.domain.repository.RachaMemberRepository;
+import br.com.rachaplus.api.domain.repository.RachaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class RachaService {
+
+    private final float defaultRating = 0.0f;
+
+    private final RachaRepository rachaRepository;
+    private final RachaMemberRepository rachaMemberRepository;
+
+    public RachaService(RachaRepository rachaRepository, RachaMemberRepository rachaMemberRepository) {
+        this.rachaRepository = rachaRepository;
+        this.rachaMemberRepository = rachaMemberRepository;
+    }
+
+    public Racha create(String name, String description, Usuario owner) {
+        var newRacha = new Racha();
+        newRacha.setName(name);
+        newRacha.setDescription(description);
+        var savedRacha = rachaRepository.save(newRacha);
+
+        var membership = new RachaMember();
+        membership.setRacha(savedRacha);
+        membership.setUser(owner);
+        membership.setRole(RachaRole.ADMIN);
+        membership.setRachaRating(defaultRating);
+
+        rachaMemberRepository.save(membership);
+
+        return savedRacha;
+    }
+
+    public List<RachaMember> listByUser(Usuario user) {
+        return rachaMemberRepository.findAllByUser(user);
+    }
+
+    public List<RachaMember> listMembers(UUID rachaId, Usuario requester) {
+        boolean isMember = rachaMemberRepository.existsByRachaIdAndUserId(rachaId, requester.getId());
+
+        if (!isMember) {
+            throw new RuntimeException("Acesso negado: você não é membro deste racha.");
+        }
+
+        return rachaMemberRepository.findAllByRachaId(rachaId);
+    }
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/Racha.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/Racha.java
@@ -1,0 +1,27 @@
+package br.com.rachaplus.api.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "rachas")
+@Data
+public class Racha {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private java.util.UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String description;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/RachaMember.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/RachaMember.java
@@ -1,0 +1,28 @@
+package br.com.rachaplus.api.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "racha_members", uniqueConstraints = @UniqueConstraint(columnNames = {"racha_id", "user_id"}))
+@Data
+public class RachaMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private java.util.UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "racha_id")
+    private Racha racha;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private Usuario user;
+
+    @Column(name = "racha_rating")
+    private float rachaRating;
+
+    @Enumerated(EnumType.STRING)
+    private RachaRole role;
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/RachaRole.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/RachaRole.java
@@ -1,0 +1,15 @@
+package br.com.rachaplus.api.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum RachaRole {
+    ADMIN("admin"),
+    PLAYER("jogador");
+
+    private final String description;
+
+    RachaRole(String description) {
+        this.description = description;
+    }
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/repository/RachaMemberRepository.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/repository/RachaMemberRepository.java
@@ -1,0 +1,16 @@
+package br.com.rachaplus.api.domain.repository;
+
+import br.com.rachaplus.api.domain.RachaMember;
+import br.com.rachaplus.api.domain.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface RachaMemberRepository extends JpaRepository<RachaMember, UUID> {
+    List<RachaMember> findAllByUser(Usuario user);
+
+    List<RachaMember> findAllByRachaId(UUID rachaId);
+
+    boolean existsByRachaIdAndUserId(UUID rachaId, UUID userId);
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/repository/RachaRepository.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/repository/RachaRepository.java
@@ -1,0 +1,9 @@
+package br.com.rachaplus.api.domain.repository;
+
+import br.com.rachaplus.api.domain.Racha;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RachaRepository extends JpaRepository<Racha, UUID> {
+}

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/repository/UsuarioRepository.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/domain/repository/UsuarioRepository.java
@@ -4,7 +4,8 @@ import br.com.rachaplus.api.domain.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
-public interface UsuarioRepository extends JpaRepository<Usuario, java.util.UUID> {
+public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
     Optional<Usuario> findByEmail(String email);
 }

--- a/rachaplus-api/src/main/java/br/com/rachaplus/api/infrastructure/controller/RachaController.java
+++ b/rachaplus-api/src/main/java/br/com/rachaplus/api/infrastructure/controller/RachaController.java
@@ -1,0 +1,60 @@
+package br.com.rachaplus.api.infrastructure.controller;
+
+import br.com.rachaplus.api.application.dto.CreateRachaDTO;
+import br.com.rachaplus.api.application.dto.RachaMemberResponseDTO;
+import br.com.rachaplus.api.application.dto.RachaResponseDTO;
+import br.com.rachaplus.api.application.service.RachaService;
+import br.com.rachaplus.api.domain.Usuario;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/rachas")
+public class RachaController {
+
+    private final RachaService rachaService;
+
+    public RachaController(RachaService rachaService) {
+        this.rachaService = rachaService;
+    }
+
+    @PostMapping
+    public ResponseEntity<RachaResponseDTO> create(@RequestBody @Valid CreateRachaDTO newRachaData, UriComponentsBuilder uriBuilder) {
+        var user = (Usuario) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        var racha = rachaService.create(newRachaData.name(), newRachaData.description(), user);
+
+        var uri = uriBuilder.path("/api/v1/rachas/{id}").buildAndExpand(racha.getId()).toUri();
+        return ResponseEntity.created(uri).body(new RachaResponseDTO(racha));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<RachaMemberResponseDTO>> listMyRachas() {
+        var user = (Usuario) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        var members = rachaService.listByUser(user);
+
+        var response = members.stream()
+                .map(RachaMemberResponseDTO::new)
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}/members")
+    public ResponseEntity<List<RachaMemberResponseDTO>> listMembers(@PathVariable UUID id) {
+        var user = (Usuario) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        var members = rachaService.listMembers(id, user);
+
+        var response = members.stream()
+                .map(RachaMemberResponseDTO::new)
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+}


### PR DESCRIPTION
Implementação da fundação técnica para grupos (rachas), garantindo que cada racha funcione como um ecossistema isolado. O usuário que cria o racha é automaticamente definido como ADMIN.

O que mudou? 🛠️

Domínio: Criação das entidades Racha e RachaMember com suporte a UUID.

Segurança: Integração com SecurityContextHolder para identificar o usuário logado sem necessidade de IDs manuais na URL.

Isolamento: Adição de lógica no RachaService para impedir que usuários visualizem membros de rachas dos quais não fazem parte.

API: Novos endpoints em /api/v1/rachas para criação, listagem pessoal e listagem de membros.

Como testar? 🧪

Fazer login para obter o token JWT.

POST /api/v1/rachas: Criar um racha e verificar o status 201 Created.

GET /api/v1/rachas: Listar seus rachas e validar se o seu usuário aparece como ADMIN.

GET /api/v1/rachas/{id}/members: Validar a lista de membros (atualmente contendo apenas o criador).